### PR TITLE
Change `prefix` to a boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ let female_names = generateUsername(10, "female");
 let male_names = generateUsername(5, "male");
 
 //With prefix
-let female_prefix = generateUsername(10, "female", "yes");
-let male_prefix = generateUsername(10, "male", "yes");
+let female_prefix = generateUsername(10, "female", true);
+let male_prefix = generateUsername(10, "male", true);
 
 console.log(female_names);
 ```

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function getRandomNumber(gender) {
   return Math.floor(Math.random() * length);
 }
 
-function generateUsername(count, gender, prefix = "no") {
+function generateUsername(count, gender, prefix = false) {
   let username, random;
   const username_list = [];
   for (let i = 0; i < count; i++) {
@@ -44,7 +44,7 @@ function generateUsername(count, gender, prefix = "no") {
     } else if (gender === "female") {
       username = girlNames[rand];
     }
-    if (prefix === "yes") {
+    if (prefix) {
       if (gender === "female") {
         random = Math.floor(Math.random() * girlPrefixes.length);
         random_prefix = girlPrefixes[random];


### PR DESCRIPTION
Booleans can only be either `true` or `false`, so it will be easier to cover than strings. For the use of the `prefix` parameter, it should be a boolean instead of a string.